### PR TITLE
Add dividers to the location search list

### DIFF
--- a/app/src/main/java/com/pnuema/android/codingchallenge/common/LightGreyDividerDecoration.kt
+++ b/app/src/main/java/com/pnuema/android/codingchallenge/common/LightGreyDividerDecoration.kt
@@ -1,0 +1,14 @@
+package com.pnuema.android.codingchallenge.common
+
+import android.content.Context
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DividerItemDecoration
+import com.pnuema.android.codingchallenge.R
+
+class LightGreyDividerDecoration(context: Context, orientation: Int) : DividerItemDecoration(context, orientation) {
+    init {
+        ContextCompat.getDrawable(context, R.drawable.grey_divider)?.let {
+            setDrawable(it)
+        }
+    }
+}

--- a/app/src/main/java/com/pnuema/android/codingchallenge/mainscreen/ui/MainActivity.kt
+++ b/app/src/main/java/com/pnuema/android/codingchallenge/mainscreen/ui/MainActivity.kt
@@ -11,9 +11,11 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.DividerItemDecoration
 import com.google.android.material.snackbar.Snackbar
 import com.pnuema.android.codingchallenge.R
 import com.pnuema.android.codingchallenge.api.LocationResultsListener
+import com.pnuema.android.codingchallenge.common.LightGreyDividerDecoration
 import com.pnuema.android.codingchallenge.fullmap.ui.FullMapActivity
 import com.pnuema.android.codingchallenge.helpers.Errors
 import com.pnuema.android.codingchallenge.mainscreen.requests.SearchRequest
@@ -51,6 +53,7 @@ class MainActivity : AppCompatActivity() {
         viewModel = ViewModelProviders.of(this).get<MainScreenViewModel>(MainScreenViewModel::class.java)
         requestor = SearchRequest()
         adapter = SearchResultsAdapter()
+        main_locations_recycler.addItemDecoration(LightGreyDividerDecoration(this, DividerItemDecoration.VERTICAL))
         main_locations_recycler.adapter = adapter
 
         savedInstanceState?.let {

--- a/app/src/main/java/com/pnuema/android/codingchallenge/mainscreen/ui/viewholders/LocationResultViewHolder.kt
+++ b/app/src/main/java/com/pnuema/android/codingchallenge/mainscreen/ui/viewholders/LocationResultViewHolder.kt
@@ -47,7 +47,6 @@ class LocationResultViewHolder(parent: ViewGroup) : RecyclerView.ViewHolder(Layo
     private fun setupFavoriteIndicator(locationResult: LocationResult) {
         val context = itemView.context
 
-        itemView.locationFavorite.setOnClickListener(null) //clear click indicator
         itemView.locationFavorite.isChecked = false //set default
 
         locationResult.id?.let {

--- a/app/src/main/res/drawable/grey_divider.xml
+++ b/app/src/main/res/drawable/grey_divider.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <size
+        android:width="1dp"
+        android:height="1dp" />
+
+    <solid android:color="@color/listDivider" />
+
+</shape>

--- a/app/src/main/res/layout/location_result_item.xml
+++ b/app/src/main/res/layout/location_result_item.xml
@@ -5,6 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:clickable="true"
+    android:focusable="true"
     android:background="?selectableItemBackground">
 
     <ImageView
@@ -73,6 +75,8 @@
         android:paddingEnd="8dp"
         android:paddingStart="0dp"
         android:gravity="center"
+        android:clickable="true"
+        android:focusable="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,5 @@
     <color name="textSecondary">#404040</color>
 
     <color name="errorBackground">#323232</color>
+    <color name="listDivider">#e6e7e9</color>
 </resources>


### PR DESCRIPTION
Dividers were needed between the items listed after a query is searched and the list of locations were returned.  This was done to give more separation to list items and help it feel like individual items in the list.